### PR TITLE
Propose to use express-interceptor instead of express-hijackresponse

### DIFF
--- a/lib/compiless.js
+++ b/lib/compiless.js
@@ -6,34 +6,43 @@ var Path = require('path'),
     csserror = require('csserror'),
     passError = require('passerror');
 
-require('express-hijackresponse');
+var interceptor = require('express-interceptor');
 
 module.exports = function compiless(options) {
     if (!options || !options.root) {
         throw new Error('options.root is mandatory');
     }
+
     var less = options.less || require('less');
     var plugins = options.plugins || [];
-    return function (req, res, next) {
-        if (/\.less(?:\?.*)?$/.test(req.url)) {
-            // Prevent If-None-Match revalidation with the downstream middleware with ETags that aren't suffixed with "-compiless":
-            var ifNoneMatch = req.headers['if-none-match'];
-            if (ifNoneMatch) {
-                var validIfNoneMatchTokens = ifNoneMatch.split(" ").filter(function (etag) {
-                    return /-compiless\"$/.test(etag);
-                });
-                if (validIfNoneMatchTokens.length > 0) {
-                    req.headers['if-none-match'] = validIfNoneMatchTokens.join(" ");
-                } else {
-                    delete req.headers['if-none-match'];
-                }
+
+    return interceptor(function (req, res) {
+        // Prevent If-None-Match revalidation with the downstream middleware with ETags that aren't suffixed with "-compiless":
+        var ifNoneMatch = req.headers['if-none-match'];
+
+        if (ifNoneMatch) {
+            var validIfNoneMatchTokens = ifNoneMatch.split(" ").filter(function (etag) {
+                return /-compiless\"$/.test(etag);
+            });
+
+            if (validIfNoneMatchTokens.length > 0) {
+                req.headers['if-none-match'] = validIfNoneMatchTokens.join(" ");
+            } else {
+                delete req.headers['if-none-match'];
             }
-            delete req.headers['if-modified-since']; // Prevent false positive conditional GETs after enabling compiless
-            res.hijack(function (err, res) {
+        }
+        delete req.headers['if-modified-since']; // Prevent false positive conditional GETs after enabling compiless
+
+        return {
+            isInterceptable: function () {
+                return /\.less(?:\?.*)?$/.test(req.url);
+            },
+            intercept: function (body, send) {
                 var contentType = res.getHeader('Content-Type'),
                     matchContentType = contentType && contentType.match(/^text\/less(?:;\s*charset=([a-z0-9\-]+))?$/i);
+
                 // The mime module doesn't support less yet, so we fall back:
-                if (matchContentType || (/\.less(?:\?.*)?$/.test(req.url) && contentType === 'application/octet-stream')) {
+                if (matchContentType || contentType === 'application/octet-stream') {
                     function formatError(err) { // err can either be a string or an error object
                         if (typeof err === 'string') {
                             return err;
@@ -49,82 +58,71 @@ module.exports = function compiless(options) {
                         res.removeHeader('Content-Length');
                         res.removeHeader('ETag');
                         res.setHeader('Content-Type', 'text/css; charset=utf-8');
-                        res.send(csserror(errorMessage) + '\n' + (cssText || ''));
+                        send(csserror(errorMessage) + '\n' + (cssText || ''));
                     }
 
-                    var chunks = [];
-                    res.on('error', function () {
-                        res.unhijack();
-                        next();
-                    }).on('data', function (chunk) {
-                        chunks.push(chunk);
-                    }).on('end', function () {
-                        if (!chunks.length) {
-                            return res.status(res.statusCode).end();
-                        }
+                    var lessText = body,
+                        baseDir = Path.resolve(options.root, req.url.replace(/\/[^\/]*(?:\?.*)?$/, '/').substr(1)),
+                        filename = Path.resolve(options.root, req.url.substr(1)),
+                        lessOptions = {
+                            paths: [baseDir],
+                            filename: filename,
+                            plugins: plugins,
+                            relativeUrls: true
+                        };
 
-                        var lessText = Buffer.concat(chunks).toString('utf-8'), // No other charsets are really relevant, right?
-                            baseDir = Path.resolve(options.root, req.url.replace(/\/[^\/]*(?:\?.*)?$/, '/').substr(1)),
-                            filename = Path.resolve(options.root, req.url.substr(1)),
-                            lessOptions = {
-                                paths: [baseDir],
-                                filename: filename,
-                                plugins: plugins,
-                                relativeUrls: true
-                            };
-
-                        less.render(lessText, lessOptions, passError(sendErrorResponse, function (output) {
-                            var importedFileNames = output.imports || [],
-                                statsByFileName = {};
-                            async.eachLimit(importedFileNames, 10, function (importedFileName, cb) {
-                                fs.stat(importedFileName, passError(cb, function (stats) {
-                                    statsByFileName[importedFileName] = stats;
-                                    cb();
-                                }));
-                            }, passError(sendErrorResponse, function () {
-                                var oldETag = res.getHeader('ETag');
-                                if (oldETag) {
-                                    var oldETagIsWeak = oldETag && /^W\//.test(oldETag),
-                                        etagFragments = [oldETag.replace(/^(?:W\/)?"|"$/g, '')];
-                                    if (importedFileNames.length) {
-                                        var importedFileStats = [];
-                                        importedFileNames.sort().forEach(function (importedFileName) {
-                                            var stats = statsByFileName[importedFileName];
-                                            importedFileStats.push(importedFileName, String(stats.mtime.getTime()), String(stats.size));
-                                        }, this);
-                                        etagFragments.push(crypto.createHash('md5').update(importedFileStats.join('-')).digest('hex').substr(0, 16));
-                                    }
-                                    var newETag = (oldETagIsWeak ? 'W/' : '') + '"' + etagFragments.join('-') + '-compiless"';
-                                    res.setHeader('ETag', newETag);
-
-                                    if (ifNoneMatch && ifNoneMatch.indexOf(newETag) !== -1) {
-                                        return res.status(304).send();
-                                    }
-                                }
-
-                                var rootCSS;
-                                try {
-                                    rootCSS = output.css;
-                                } catch (e) {
-                                    return sendErrorResponse(e);
-                                }
-
-                                var cssText = importedFileNames.map(function (importedFileName) {
-                                    return ".compilessinclude {background-image: url(" + Path.relative(baseDir, importedFileName) + "); display: none;}\n";
-                                }).join("") + rootCSS;
-                                res.setHeader('Content-Type', 'text/css; charset=utf-8');
-                                res.setHeader('Content-Length', Buffer.byteLength(cssText));
-                                res.end(cssText);
+                    less.render(lessText, lessOptions, passError(sendErrorResponse, function (output) {
+                        var importedFileNames = output.imports || [],
+                            statsByFileName = {};
+                        async.eachLimit(importedFileNames, 10, function (importedFileName, cb) {
+                            fs.stat(importedFileName, passError(cb, function (stats) {
+                                statsByFileName[importedFileName] = stats;
+                                cb();
                             }));
+                        }, passError(sendErrorResponse, function () {
+                            var oldETag = res.getHeader('ETag');
+
+                            if (oldETag) {
+                                var oldETagIsWeak = oldETag && /^W\//.test(oldETag),
+                                    etagFragments = [oldETag.replace(/^(?:W\/)?"|"$/g, '')];
+
+                                if (importedFileNames.length) {
+                                    var importedFileStats = [];
+
+                                    importedFileNames.sort().forEach(function (importedFileName) {
+                                        var stats = statsByFileName[importedFileName];
+                                        importedFileStats.push(importedFileName, String(stats.mtime.getTime()), String(stats.size));
+                                    }, this);
+
+                                    etagFragments.push(crypto.createHash('md5').update(importedFileStats.join('-')).digest('hex').substr(0, 16));
+                                }
+
+                                var newETag = (oldETagIsWeak ? 'W/' : '') + '"' + etagFragments.join('-') + '-compiless"';
+                                res.setHeader('ETag', newETag);
+
+                                if (ifNoneMatch && ifNoneMatch.indexOf(newETag) !== -1) {
+                                    return send(res.status(304));
+                                }
+                            }
+
+                            var rootCSS;
+                            try {
+                                rootCSS = output.css;
+                            } catch (e) {
+                                return sendErrorResponse(e);
+                            }
+
+                            var cssText = importedFileNames.map(function (importedFileName) {
+                                return ".compilessinclude {background-image: url(" + Path.relative(baseDir, importedFileName) + "); display: none;}\n";
+                            }).join("") + rootCSS;
+
+                            res.setHeader('Content-Type', 'text/css; charset=utf-8');
+                            res.setHeader('Content-Length', Buffer.byteLength(cssText));
+                            send(cssText);
                         }));
-                    });
-                } else {
-                    res.unhijack(true);
+                    }));
                 }
-            });
-            next();
-        } else {
-            next();
-        }
-    };
+            }
+        };
+    });
 };

--- a/lib/compiless.js
+++ b/lib/compiless.js
@@ -4,9 +4,8 @@ var Path = require('path'),
     fs = require('fs'),
     async = require('async'),
     csserror = require('csserror'),
-    passError = require('passerror');
-
-var interceptor = require('express-interceptor');
+    passError = require('passerror'),
+    interceptor = require('express-interceptor');
 
 module.exports = function compiless(options) {
     if (!options || !options.root) {
@@ -35,14 +34,14 @@ module.exports = function compiless(options) {
 
         return {
             isInterceptable: function () {
-                return /\.less(?:\?.*)?$/.test(req.url);
+                return true;
             },
             intercept: function (body, send) {
                 var contentType = res.getHeader('Content-Type'),
                     matchContentType = contentType && contentType.match(/^text\/less(?:;\s*charset=([a-z0-9\-]+))?$/i);
 
                 // The mime module doesn't support less yet, so we fall back:
-                if (matchContentType || contentType === 'application/octet-stream') {
+                if (matchContentType || (/\.less(?:\?.*)?$/.test(req.url) && contentType === 'application/octet-stream')) {
                     function formatError(err) { // err can either be a string or an error object
                         if (typeof err === 'string') {
                             return err;
@@ -101,7 +100,7 @@ module.exports = function compiless(options) {
                                 res.setHeader('ETag', newETag);
 
                                 if (ifNoneMatch && ifNoneMatch.indexOf(newETag) !== -1) {
-                                    return send(res.status(304));
+                                    return res.status(304).send();
                                 }
                             }
 
@@ -121,6 +120,8 @@ module.exports = function compiless(options) {
                             send(cssText);
                         }));
                     }));
+                } else {
+                    send(body);
                 }
             }
         };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "async": "=0.2.9",
     "csserror": "^1.0.1",
-    "express-hijackresponse": "0.2.1",
+    "express-interceptor": "1.0.0",
     "less": ">= 2.4.0",
     "passerror": "1.1.0"
   },


### PR DESCRIPTION
Hello there,

The idea behind this PR is to replace express-hijackresponse dependency for another module called express-interceptor, it allows you to define a previous step before sending a response and do whatever you need with it. Also you can avoid calling next() over and over and overall it helps to have a cleaner base code. 