### PR TITLE
The interception shouldn't happen for non-'less' requests (previous v…

### DIFF
--- a/lib/compiless.js
+++ b/lib/compiless.js
@@ -20,25 +20,16 @@ module.exports = function compiless(options) {
     var toCSSOptions = options.toCSSOptions || {};
 
     return interceptor(function (req, res) {
-        // Prevent If-None-Match revalidation with the downstream middleware with ETags that aren't suffixed with "-compiless":
-        var ifNoneMatch = req.headers['if-none-match'];
-
-        if (ifNoneMatch) {
-            var validIfNoneMatchTokens = ifNoneMatch.split(" ").filter(function (etag) {
-                return /-compiless\"$/.test(etag);
-            });
-
-            if (validIfNoneMatchTokens.length > 0) {
-                req.headers['if-none-match'] = validIfNoneMatchTokens.join(" ");
-            } else {
-                delete req.headers['if-none-match'];
-            }
-        }
-        delete req.headers['if-modified-since']; // Prevent false positive conditional GETs after enabling compiless
-
         return {
             isInterceptable: function () {
-                return true;
+                var contentType = res.getHeader('Content-Type'),
+                    matchContentType = contentType && contentType.match(/^text\/less(?:;\s*charset=([a-z0-9\-]+))?$/i);
+                // The mime module doesn't support less yet
+                if (matchContentType || (/\.less(?:\?.*)?$/.test(req.url) && contentType === 'application/octet-stream')) {
+                    return true;
+                } else {
+                    return false;
+                }
             },
             intercept: function (body, send) {
                 function formatError(err) { // err can either be a string or an error object
@@ -93,6 +84,7 @@ module.exports = function compiless(options) {
                             }
                         }
 
+
                         var cssText = importedFileNames.map(function (importedFileName) {
                             return ".compilessinclude {background-image: url(" + Path.relative(baseDir, importedFileName) + "); display: none;}\n";
                         }).join("") + css;
@@ -103,39 +95,47 @@ module.exports = function compiless(options) {
                     }));
                 }
 
-                var contentType = res.getHeader('Content-Type'),
-                    matchContentType = contentType && contentType.match(/^text\/less(?:;\s*charset=([a-z0-9\-]+))?$/i);
+                // Prevent If-None-Match revalidation with the downstream middleware with ETags that aren't suffixed with "-compiless":
+                var ifNoneMatch = req.headers['if-none-match'];
 
-                // The mime module doesn't support less yet, so we fall back:
-                if (matchContentType || (/\.less(?:\?.*)?$/.test(req.url) && contentType === 'application/octet-stream')) {
-                    var lessText = body,
-                        baseDir = Path.resolve(options.root, req.url.replace(/\/[^\/]*(?:\?.*)?$/, '/').substr(1)),
-                        filename = Path.resolve(options.root, req.url.substr(1)),
-                        lessOptions = {
-                            paths: [baseDir],
-                            filename: filename,
-                            plugins: plugins,
-                            relativeUrls: true
-                        };
+                if (ifNoneMatch) {
+                    var validIfNoneMatchTokens = ifNoneMatch.split(" ").filter(function (etag) {
+                        return /-compiless\"$/.test(etag);
+                    });
 
-                    if (isOldLessApi) {
-                        var parser = new less.Parser(lessOptions);
-                        parser.parse(lessText, passError(sendErrorResponse, function (root) {
-                            var css;
-                            try {
-                                css = root.toCSS(toCSSOptions);
-                            } catch (e) {
-                                return sendErrorResponse(e);
-                            }
-                            respondWithCss(css, parser.imports && parser.imports.files && Object.keys(parser.imports.files));
-                        }));
+                    if (validIfNoneMatchTokens.length > 0) {
+                        req.headers['if-none-match'] = validIfNoneMatchTokens.join(" ");
                     } else {
-                        less.render(lessText, lessOptions, passError(sendErrorResponse, function (output) {
-                            respondWithCss(output.css, output.imports);
-                        }));
+                        delete req.headers['if-none-match'];
                     }
+                }
+                delete req.headers['if-modified-since']; // Prevent false positive conditional GETs after enabling compiless
+
+                var lessText = body,
+                    baseDir = Path.resolve(options.root, req.url.replace(/\/[^\/]*(?:\?.*)?$/, '/').substr(1)),
+                    filename = Path.resolve(options.root, req.url.substr(1)),
+                    lessOptions = {
+                        paths: [baseDir],
+                        filename: filename,
+                        plugins: plugins,
+                        relativeUrls: true
+                    };
+
+                if (isOldLessApi) {
+                    var parser = new less.Parser(lessOptions);
+                    parser.parse(lessText, passError(sendErrorResponse, function (root) {
+                        var css;
+                        try {
+                            css = root.toCSS(toCSSOptions);
+                        } catch (e) {
+                            return sendErrorResponse(e);
+                        }
+                        respondWithCss(css, parser.imports && parser.imports.files && Object.keys(parser.imports.files));
+                    }));
                 } else {
-                    send(body);
+                    less.render(lessText, lessOptions, passError(sendErrorResponse, function (output) {
+                        respondWithCss(output.css, output.imports);
+                    }));
                 }
             }
         };


### PR DESCRIPTION
…ersion was modifying headers)

"isInterceptable()" was hard-coded to return true & the intercept code was also processing non-'less' requests.

eg: Image files were losing Content-length header and Transfer-Encoding chunk was being added due to the "send(body);" used when non-'less' requests were being intercepted.

Moved all the header modifying code to happen only if interception is required ('less' requests only)